### PR TITLE
Add an option to quickly generate simple polyrhythms

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If everything's worked, you should be able to run the tests, with:
 
 	bundle exec rspec
 
-And view Inevitable Cacophony options, with:
+and view Inevitable Cacophony options, with:
 
 	bundle exec ruby -Ilib cacophony.rb --help
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ To play a specific rhythm (in the notation used by the game):
 	ruby -Ilib cacophony.rb --beat -e '| ! x X x |' | aplay
 
 
+You can also play polyrhythms where each component rhythm is simply | x x ... x |.
+(More complex rhythms are possible but you'll need to write out a full musical form to describe them.)
+
+	ruby -Ilib cacophony.rb --beat --polyrhythm 7:11 | aplay
+
+
 To generate a tune from a given form description (support is pretty limited so far):
 
 	ruby -Ilib cacophony.rb < form_description.txt | aplay

--- a/README.md
+++ b/README.md
@@ -4,7 +4,35 @@
 
 An attempt to automatically generate music in Dwarf Fortress' generated musical styles.
 
+## Installation / Dev Setup
+
+To use, or work on, Inevitable Cacophony you will need some Ruby development tools installed,
+starting with the Ruby language itself. Normally you'd install Ruby using a version manager,
+such as [RVM](https://rvm.io/rvm/basics). (I believe that only works on Unix systems;
+I'm not sure what you'd do on Windows, sorry.)
+
+Once you have RVM installed, running `rvm use` will read the `.ruby_version` file,
+and enable the correct Ruby in your shell (or tell you how to install it, if needed).
+
+You will then need to install the Ruby "gems" Cacophony depends on, which is done through
+[Bundler](https://bundler.io/#getting-started). Once you have Bundler installed,
+running `bundle install` will install all the necessary dependencies.
+
+If everything's worked, you should be able to run the tests, with:
+
+	bundle exec rspec
+
+And view Inevitable Cacophony options, with:
+
+	bundle exec ruby -Ilib cacophony.rb --help
+
+
+See the next section for further instructions.
+
 ## Usage
+
+All these commands may need `bundle exec` at the start to get them to work.
+They seem to work without it for me, but your Ruby setup might be different.
 
 To play a specific rhythm (in the notation used by the game):
 

--- a/cacophony.rb
+++ b/cacophony.rb
@@ -96,20 +96,13 @@ OptionParser.new do |opts|
 		}
 	end
 
-	opts.on('-7', '--seven-eleven', 'Play a 7:11 Polyrhythm') do
-		command = -> {
-			seven = Parser::RhythmLine.new.parse('| x x x x x x x |')
-			eleven = Parser::RhythmLine.new.parse('| x x x x x x x x x x x |')
-			seven_eleven = Polyrhythm.new(seven, eleven)
+	opts.on('-p', '--polyrhythm RATIO', "Rather than loading rhythm normally, use a polyrhythm in the given ratio (e.g 7:11, 2:3:4). The first number will be 'primary' and determine the tempo.") do |ratio|
+		components = ratio.split(':').map do |length|
+			Rhythm.new([Rhythm::Beat.new(1, 1, 0)] * length.to_i)
+		end
 
-                        notes = 3.times.map do
-                                seven_eleven.each_beat.map do |beat|
-                                        Note.new(440, beat)
-                                end
-                        end.flatten
-
-                        tone.add_phrase(Phrase.new(*notes, tempo: options[:tempo]))
-		}
+		primary, *secondaries = components
+		@rhythm = Polyrhythm.new(primary, secondaries)
 	end
 
 	opts.on('-e', '--eval FORM', 'Parse FORM rather than reading a form description from stdin') do |form|

--- a/spec/integration/gold_master_spec.rb
+++ b/spec/integration/gold_master_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe 'Inevitable Cacophony' do
 			end
 		end
 
-		context 'for the builtin 7-11 test polyrhythm' do
+		context 'from given basic polyrhythms' do
 			let(:generated_data) do
-				generate_with_args('-7')
+				generate_with_args('--polyrhythm', '7:11', '--beat')
 			end
 			let(:fixture_file) { 'spec/fixtures/7-11-polyrhythm.wav' }
 


### PR DESCRIPTION
I originally had a 7:11 polyrhythm as a quick demo of the polyrhythm algorithm, but it turns out generating specific polyrhythms is handy on its own, outside of the Dwarf Fortress context.

This PR adds an option to quickly generate simple polyrhythms (without accented, silent, or swung beats) without having to write a full musical form. 